### PR TITLE
feat: Refactor EventsService to include polling for events

### DIFF
--- a/src/app/features/home/events/events.component.html
+++ b/src/app/features/home/events/events.component.html
@@ -1,9 +1,12 @@
-<p>events works!</p>
-<pre>
+
+<section class="events-container">
+  <pre>
     {{events$ | async | json}}
 </pre>
-visualizzi la lista degli eventi
 ---
-@defer(when currentUserType === userTypes.MASTER){
-  <app-form [formConfig]="formConfig" (onSubmit)="handleCreation($event)"/>
+@if(currentUserType === userTypes.MASTER){
+  <div class="events-master-form">
+    <app-form [formConfig]="formConfig" (onSubmit)="handleCreation($event)"/>
+  </div>
 }
+</section>

--- a/src/app/features/home/events/events.component.scss
+++ b/src/app/features/home/events/events.component.scss
@@ -1,0 +1,9 @@
+@use "@angular/material" as mat;
+@use "../../../../styles/theme/m3-theme.scss" as m3;
+@include mat.core();
+
+.events-master-form{
+    position: sticky;
+    bottom: 0;
+    background-color: mat.get-theme-color(m3.$light-theme, primary, 99);
+}

--- a/src/app/features/home/events/events.component.ts
+++ b/src/app/features/home/events/events.component.ts
@@ -1,4 +1,9 @@
-import { ChangeDetectionStrategy, Component, inject, OnInit } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  inject,
+  OnInit,
+} from '@angular/core';
 import { EssentialComponent } from '../../../core/components/essentialComponent';
 import { AuthService } from '../../../core/services/auth.service';
 import { UserTypes } from '../../../core/models/users';
@@ -18,15 +23,18 @@ export class EventsComponent extends EssentialComponent implements OnInit {
   userTypes = UserTypes;
   formConfig = EventForm;
   currentUserType = this.authService.currentUser.type;
-  events$ = this.eventsService.events$
+  events$ = this.eventsService.events$;
 
-  ngOnInit(){
-    this.eventsService.getEventsList()
+  ngOnInit() {
+    this.eventsService.pollEvents();
   }
 
   handleCreation(event: Partial<GameEvent>) {
+    this.eventsService.createEvent(event);
+  }
 
-      this.eventsService.createEvent(event)
+  override ngOnDestroy(): void {
+      this.eventsService.destroyPollEvents()
 
   }
 }

--- a/src/app/shared/loading/loading.interceptor.ts
+++ b/src/app/shared/loading/loading.interceptor.ts
@@ -14,20 +14,27 @@ export const loadingInterceptor: HttpInterceptorFn = (
 ): Observable<HttpEvent<unknown>> => {
   const loadingService = inject(LoadingService);
   // aumento il conteggio di loading
-  loadingService.loadingCount += 1;
-  return next(req).pipe(
-    catchError((_err) => {
-      // se c'è un errore setto a 0 il loading
-      loadingService.loadingCount = 0;
-      throw _err;
-    }),
-    finalize(() => {
-      // metto in sicurezza che il valore minimo sia sempre 0
-      if (loadingService.loadingCount < 0) {
+  const isLoadingDisabled = req.headers.get('disableLoading')
+ 
+  if(!isLoadingDisabled){
+    loadingService.loadingCount += 1;
+    return next(req).pipe(
+      catchError((_err) => {
+        // se c'è un errore setto a 0 il loading
         loadingService.loadingCount = 0;
-      } else {
-        loadingService.loadingCount -= 1;
-      }
-    })
-  );
+        throw _err;
+      }),
+      finalize(() => {
+          if (loadingService.loadingCount < 0) {
+            loadingService.loadingCount = 0;
+          } else {
+            loadingService.loadingCount -= 1;
+          }
+        // metto in sicurezza che il valore minimo sia sempre 0
+      })
+    );
+  }else{
+    return next(req)
+  }
+ 
 };


### PR DESCRIPTION
The code changes in this commit refactor the EventsService to include polling for events. The `getEventsList` method is modified to return an Observable of GameEvent[], and a new `pollEvents` method is added to continuously fetch the events list at regular intervals. The `destroyPollEvents` method is also added to stop the polling when needed.

This commit also includes changes to the EventsComponent, where the `pollEvents` method is called in the `ngOnInit` lifecycle hook to start the polling, and the `destroyPollEvents` method is called in the `ngOnDestroy` lifecycle hook to stop the polling.

Additionally, the loading interceptor is updated to include a check for the `disableLoading` header in the request. If the header is present, the interceptor skips the loading logic.

This commit addresses the need to continuously fetch the events list and improves the overall user experience by providing real-time updates.